### PR TITLE
Refactored core urls and auth views and cleaned up settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,5 +66,13 @@ bash:
 fmtlint:
 	docker-compose -f ${COMPOSE_FILE} run ${COMPOSE_CONTAINER_NAME} black . && flake8 .
 
+.PHONY: create-admin-user
+create-admin-user:
+	docker-compose -f ${COMPOSE_FILE} run ${COMPOSE_CONTAINER_NAME} python src/manage.py create_admin_user \
+	--noinput \
+	--username admin \
+	--password admin \
+	--email admin@hotmail.com
+
 .PHONY: create-db
 create-db: stop prune db migrate

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![CI](https://github.com/Kandeel4411/peam-backend/workflows/CI/badge.svg?branch=main)
 [![Python: 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Generic badge](https://img.shields.io/badge/django-3.2-blue.svg)](https://shields.io/)
 [![Code-style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 Backend repository for the Peam app.

--- a/src/core/auth/adapters.py
+++ b/src/core/auth/adapters.py
@@ -1,0 +1,20 @@
+from django.contrib.sites.shortcuts import get_current_site
+from allauth.account.adapter import DefaultAccountAdapter
+from django.urls import reverse, URLPattern
+from django.conf import settings
+
+
+class CustomAccountAdapter(DefaultAccountAdapter):
+    """
+    Custom allauth account adapter
+    """
+
+    def get_email_confirmation_url(self, request, emailconfirmation):
+        """
+        Constructs the email confirmation (activation) url.
+        """
+        site = get_current_site(request)
+        location = reverse("account_confirm_email", args=[emailconfirmation.key])
+
+        protocol: str = settings.ACCOUNT_DEFAULT_HTTP_PROTOCOL
+        return f"{protocol}://{site.domain}{location}"

--- a/src/core/auth/serializers.py
+++ b/src/core/auth/serializers.py
@@ -4,8 +4,20 @@ from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from dj_rest_auth.registration.serializers import RegisterSerializer
 
+from users.serializers import UserSerializer
 
 User = get_user_model()
+
+
+# ! This is mainly for swagger documentation purposes
+class LoginResponseSerializer(serializers.Serializer):
+    """
+    Custom serializer used to represent response for auth login view
+    """
+
+    access_token = serializers.CharField(required=True)
+    refresh_token = serializers.CharField(required=True)
+    user = UserSerializer(required=True, many=False)
 
 
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):

--- a/src/core/auth/views.py
+++ b/src/core/auth/views.py
@@ -1,0 +1,37 @@
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.views import status
+from django.utils.decorators import method_decorator
+from dj_rest_auth.serializers import LoginSerializer, PasswordChangeSerializer
+from dj_rest_auth.views import (
+    LoginView,
+    PasswordChangeView,
+    UserDetailsView,
+)
+
+from users.serializers import UserSerializer
+from .serializers import LoginResponseSerializer
+
+
+# TODO: Figure out a better method to redecorate views
+LoginView = swagger_auto_schema(
+    method="post",
+    request_body=LoginSerializer(),
+    responses={status.HTTP_200_OK: LoginResponseSerializer()},
+)(LoginView.as_view())
+
+PasswordChangeView = swagger_auto_schema(
+    method="post",
+    request_body=PasswordChangeSerializer(),
+    responses={status.HTTP_200_OK: "New password has been saved."},
+)(PasswordChangeView.as_view())
+
+UserDetailsView = swagger_auto_schema(
+    method="get",
+    responses={status.HTTP_200_OK: UserSerializer()},
+)(UserDetailsView.as_view())
+
+UserDetailsView = swagger_auto_schema(
+    methods=["patch", "put"],
+    request_body=UserSerializer(),
+    responses={status.HTTP_200_OK: UserSerializer()},
+)(UserDetailsView)

--- a/src/core/management/commands/create_admin_user.py
+++ b/src/core/management/commands/create_admin_user.py
@@ -1,0 +1,46 @@
+from django.db import transaction
+from django.contrib.auth.management.commands import createsuperuser
+from django.core.management import CommandError
+from allauth.account.models import EmailAddress
+
+
+class Command(createsuperuser.Command):
+    help = "Crate a superuser, and allow password to be provided"
+
+    def add_arguments(self, parser) -> None:
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            "--password",
+            dest="password",
+            default=None,
+            help="Specifies the password for the superuser.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        password: str = options.get("password")
+        email: str = options.get("email")
+        username: str = options.get("username")
+        database: str = options.get("database")
+
+        if password and not username:
+            raise CommandError("--username is required if specifying --password")
+        if email and EmailAddress.objects.filter(email=email).exists():
+            raise CommandError("User with given email already exists.")
+
+        with transaction.atomic():
+            super(Command, self).handle(*args, **options)
+
+            user = self.UserModel._default_manager.db_manager(database).get(username=username)
+
+            if email:
+                # Verify user's email
+                EmailAddress.objects.create(
+                    user=user,
+                    email=user.email,
+                    primary=True,
+                    verified=True,
+                )
+
+            if password:
+                user.set_password(password)
+                user.save()

--- a/src/core/settings/base.py
+++ b/src/core/settings/base.py
@@ -73,6 +73,11 @@ AUTH_USER_MODEL = "users.User"
 LOGIN_REDIRECT_URL = "/"
 LOGIN_URL = "/api/auth/login"
 
+# django path url patterns
+FRONTEND_EMAIL_CONFIRMATION_URL = "signup/email/verify/<str:key>"
+FRONTEND_PASSWORD_RESET_CONFIRMATION_URL = "password/reset/confirm/<slug:uidb64>/<slug:token>"
+
+
 # dj-rest-auth
 # ------------------------------------------------------------------------------
 REST_USE_JWT = True
@@ -84,17 +89,18 @@ JWT_AUTH_SAMESITE = "Lax"
 
 REST_AUTH_SERIALIZERS = {
     "JWT_TOKEN_CLAIMS_SERIALIZER": "core.auth.serializers.CustomTokenObtainPairSerializer",
+    "USER_DETAILS_SERIALIZER": "users.serializers.UserSerializer",
 }
 
 REST_AUTH_REGISTER_SERIALIZERS = {"REGISTER_SERIALIZER": "core.auth.serializers.CustomRegisterSerializer"}
 
 # django-allauth
 # ------------------------------------------------------------------------------
-ACCOUNT_LOGIN_ATTEMPTS_LIMIT = 8
+ACCOUNT_LOGIN_ATTEMPTS_LIMIT = 4
 ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT = 300
 ACCOUNT_AUTHENTICATION_METHOD = "username_email"
 
-ACCOUNT_CONFIRM_EMAIL_ON_GET = True
+ACCOUNT_CONFIRM_EMAIL_ON_GET = False
 ACCOUNT_EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL = None
 ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 1
 ACCOUNT_EMAIL_CONFIRMATION_HMAC = True
@@ -106,11 +112,13 @@ ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_MAX_EMAIL_ADDRESSES = 1  # User wont be able to change his email
+ACCOUNT_PRESERVE_USERNAME_CASING = False  # Always save username in lowercase
 
 ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE = True
 ACCOUNT_LOGIN_ON_PASSWORD_RESET = False
 
-ACCOUNT_PRESERVE_USERNAME_CASING = True
+ACCOUNT_ADAPTER = "core.auth.adapters.CustomAccountAdapter"
+ACCOUNT_DEFAULT_HTTP_PROTOCOL = "http"
 
 # djangorestframework-simplejwt
 # ------------------------------------------------------------------------------
@@ -141,10 +149,10 @@ PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.BCryptSHA256PasswordHasher",
 ]
 AUTH_PASSWORD_VALIDATORS = [
-    {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
-    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
-    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
-    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+    # {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
+    # {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    # {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    # {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
 # MIDDLEWARE
@@ -153,8 +161,8 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
-    "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/src/core/settings/dev.py
+++ b/src/core/settings/dev.py
@@ -23,75 +23,21 @@ CORS_ALLOW_ALL_ORIGINS = True
 
 # AUTHENTICATION
 # ------------------------------------------------------------------------------
-AUTHENTICATION_BACKENDS = [
-    # allauth specific authentication methods, such as login by e-mail
-    "allauth.account.auth_backends.AuthenticationBackend",
-    # Needed to login by username in Django admin, regardless of allauth
-    "django.contrib.auth.backends.ModelBackend",
-]
-
-AUTH_USER_MODEL = "users.User"
-
-LOGIN_REDIRECT_URL = "/"
-LOGIN_URL = "/api/auth/login"
 
 # dj-rest-auth
 # ------------------------------------------------------------------------------
-REST_USE_JWT = True
-REST_SESSION_LOGIN = False
-JWT_AUTH_COOKIE = "jwt-auth"
-JWT_AUTH_SECURE = False
-JWT_AUTH_HTTPONLY = True
-JWT_AUTH_SAMESITE = "Lax"
-
-REST_AUTH_SERIALIZERS = {
-    "JWT_TOKEN_CLAIMS_SERIALIZER": "core.auth.serializers.CustomTokenObtainPairSerializer",
-}
-
-REST_AUTH_REGISTER_SERIALIZERS = {"REGISTER_SERIALIZER": "core.auth.serializers.CustomRegisterSerializer"}
 
 # django-allauth
 # ------------------------------------------------------------------------------
 ACCOUNT_LOGIN_ATTEMPTS_LIMIT = 8
-ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT = 300
-ACCOUNT_AUTHENTICATION_METHOD = "username_email"
-
-ACCOUNT_CONFIRM_EMAIL_ON_GET = True
-ACCOUNT_EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL = None
-ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 1
-ACCOUNT_EMAIL_CONFIRMATION_HMAC = True
-
-ACCOUNT_USER_MODEL_EMAIL_FIELD = "email"
-ACCOUNT_USER_MODEL_USERNAME_FIELD = "username"
-ACCOUNT_USERNAME_REQUIRED = True
-ACCOUNT_EMAIL_REQUIRED = True
-ACCOUNT_UNIQUE_EMAIL = True
-ACCOUNT_EMAIL_VERIFICATION = "mandatory"
-ACCOUNT_MAX_EMAIL_ADDRESSES = 1  # User wont be able to change his email
-
-ACCOUNT_LOGOUT_ON_PASSWORD_CHANGE = True
-ACCOUNT_LOGIN_ON_PASSWORD_RESET = False
-
-ACCOUNT_PRESERVE_USERNAME_CASING = True
 
 # djangorestframework-simplejwt
 # ------------------------------------------------------------------------------
-SIMPLE_JWT = {
-    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=10),
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
-    "ROTATE_REFRESH_TOKENS": False,
-    "ALGORITHM": "HS256",
-    "SIGNING_KEY": env("JWT_KEY", default=SECRET_KEY),
-    "AUTH_HEARDER_TYPES": ("Bearer",),
-    "AUTH_HEADER_NAME": "HTTP_AUTHORIZATION",
-    "AUDIENCE": None,
-    "ISSUER": None,
-    "USER_ID_FIELD": "uid",
-    "USER_ID_CLAIM": "user_id",
-    "JTI_CLAIM": "jwt_id",
-    "TOKEN_TYPE_CLAIM": "jwt_type",
-    "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
-}
+SIMPLE_JWT = SIMPLE_JWT.update(  # noqa
+    {
+        "SIGNING_KEY": env("JWT_KEY", default=SECRET_KEY),
+    }
+)
 
 # django-rest-framework
 # -------------------------------------------------------------------------------

--- a/src/core/settings/prod.py
+++ b/src/core/settings/prod.py
@@ -42,12 +42,6 @@ JWT_AUTH_SECURE = True
 JWT_AUTH_HTTPONLY = True
 JWT_AUTH_SAMESITE = "Lax"
 
-REST_AUTH_SERIALIZERS = {
-    "JWT_TOKEN_CLAIMS_SERIALIZER": "core.auth.serializers.CustomTokenObtainPairSerializer",
-}
-
-REST_AUTH_REGISTER_SERIALIZERS = {"REGISTER_SERIALIZER": "core.auth.serializers.CustomRegisterSerializer"}
-
 # django-allauth
 # ------------------------------------------------------------------------------
 ACCOUNT_LOGIN_ATTEMPTS_LIMIT = 8

--- a/src/courses/urls.py
+++ b/src/courses/urls.py
@@ -24,7 +24,7 @@ requirement_detail_pattern = f"{requirement_pattern}<str:requirement_title>/"
 
 # Project requirement attachment patterns
 requirement_attachment_pattern = f"{requirement_detail_pattern}attachments/"
-requirement_attachment_detail_pattern = f"{requirement_attachment_pattern}<str:attachment_id>/"
+requirement_attachment_detail_pattern = f"{requirement_attachment_pattern}<slug:attachment_id>/"
 
 # Project requirement team patterns
 requirement_team_pattern = f"{requirement_detail_pattern}teams/"
@@ -32,7 +32,7 @@ requirement_team_detail_pattern = f"{requirement_team_pattern}<str:team_name>/"
 
 # Course attachment patterns
 course_attachment_pattern = f"{course_detail_pattern}attachments/"
-course_attachment_detail_pattern = f"{course_attachment_pattern}<str:attachment_id>/"
+course_attachment_detail_pattern = f"{course_attachment_pattern}<slug:attachment_id>/"
 
 urlpatterns = [
     path(course_pattern, CourseView.as_view(), name="courses"),

--- a/src/users/serializers.py
+++ b/src/users/serializers.py
@@ -1,5 +1,9 @@
+from typing import Optional
+
 from rest_framework import serializers
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from dj_rest_auth.serializers import UserDetailsSerializer
 
 User = get_user_model()
 
@@ -9,7 +13,25 @@ class UserSerializer(serializers.ModelSerializer):
     A serializer responsible for handling User instances.
     """
 
+    full_name = serializers.SerializerMethodField("get_full_name", read_only=True, required=False)
+
     class Meta:
         model = User
-        fields = ["uid", "avatar", "username", "email", "first_name", "last_name"]
-        read_only_fields = ["uid"]
+        fields = ("uid", "avatar", "username", "email", "first_name", "last_name", "full_name")
+        read_only_fields = ("uid", "email")
+        extra_kwargs = {"first_name": {"write_only": True}, "last_name": {"write_only": True}}
+
+    def get_full_name(self, obj: Meta.model) -> Optional[str]:
+        """
+        Method that returns the full name of the user
+        """
+        if obj.first_name or obj.last_name:
+            return f"{obj.first_name} {obj.last_name}"
+        return None
+
+    def validate_username(self, username: str) -> str:
+        """
+        Overriding username validation
+        """
+        # dj-rest-auth username validation
+        return UserDetailsSerializer.validate_username(self, username)


### PR DESCRIPTION
- Removed unnecessary dev settings
- Refactored core urls to be more organised ( hopefully )
- Changed the way auth views were included ( they are now included manually by hand to allow for better flexibility in changing route patterns )
- Refactored `UserSerializer` per usecase
- Improved swagger doc generation for most of auth views
- Minor `create_admin_user` utility added to Makefile and `manage.py` and django badge to keep track of django version in README
- Changed/Fixed the way email and password verification were handled ( moved responsibility to client instead  of  direct API verification, in other words,  emails  sent will include links to client routes that will then send requests to specific API endpoints for verification/confirmation )